### PR TITLE
Fix foresight donation

### DIFF
--- a/donor_info.toml
+++ b/donor_info.toml
@@ -1,5 +1,5 @@
 [[donor]]
-customer_id = "every.org:f92d255e-b838-4bd9-bf02-2f64416da60f"
+customer_id = "every.org:f38d804d-7ac9-4bc2-a623-64770ae11d25"
 link = "https://www.fslabs.ca"
 logo = "Foresight_Spatial_Labs.svg"
 


### PR DESCRIPTION
Note that they have paid in advance until May 10th, and the donation will drop off on 3/26, so we will need to turn it into a manual donation after that.